### PR TITLE
[FIX] invalid namespace

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -25,7 +25,7 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
 	public function on($eventKey, $data = null) {
 		// check $eventKey for which you have registered
 		if ($eventKey == 'plugins_loaded') {
-			\Phile\ServiceLocator::registerService('Phile_Parser', new \Phile\Parser\Textile($this->settings));
+			\Phile\ServiceLocator::registerService('Phile_Parser', new \Phile\Plugin\Phile\Textile\Parser($this->settings));
 		}
 	}
 }


### PR DESCRIPTION
I was trying out the plugin, but bumped into the same error as mentioned in issue #2 . The fatal error was due to the invalid namespace `\Phile\Parser\Textile`, which should actually be `\Phile\Plugin\Phile\Textile\Parser` since Phile v1.x

Oh, and best wishes for the new year! :tada: 
